### PR TITLE
Closing resources correctly.

### DIFF
--- a/src/main/java/com/airhacks/afterburner/injection/InjectionProvider.java
+++ b/src/main/java/com/airhacks/afterburner/injection/InjectionProvider.java
@@ -95,8 +95,7 @@ public class InjectionProvider {
 
     static Properties getProperties(Class clazz) {
         Properties configuration = new Properties();
-        try {
-            final InputStream stream = clazz.getResourceAsStream(CONFIGURATION_FILE);
+        try (InputStream stream = clazz.getResourceAsStream(CONFIGURATION_FILE)) {
             if (stream == null) {
                 return null;
             }


### PR DESCRIPTION
Hi Adam,

I realized that InputStream is not closed correctly in getProperties() method. This leads to errors on iOS using roboVM.

BR
Dino
