### PR TITLE
Add logger and more javadocs to FXMLView

### DIFF
--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -168,7 +168,7 @@ public abstract class FXMLView {
         String styleSheetName = getStyleSheetName();
         URL uri = getClass().getResource(styleSheetName);
         if (uri == null) {
-            log.info("Could not find " + styleSheetName);
+            log.fine("Could not find " + styleSheetName);
             return;
         }
         String uriToCss = uri.toExternalForm();
@@ -271,7 +271,7 @@ public abstract class FXMLView {
         try {
             return getBundle(name);
         } catch (MissingResourceException ex) {
-            log.info("Was not able to find resource bundle: " + name);
+            log.fine("Was not able to find resource bundle: " + name);
             return null;
         }
     }


### PR DESCRIPTION
Hi Adam,
I just started using afterburner.fx. It is awesome. I am very familiar with Java EE 6 and the possibility to use the same injection in an Java FX application rocks.

I enhanced the documentation for the FXMLView and added a logger to see if some non available resources or css files are silently ignored.
I ran the tests and they are still completely working:

---
##  T E S T S

objc[3926]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/jre/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.
Running com.airhacks.afterburner.injection.InjectionProviderTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.22 sec
Running com.airhacks.afterburner.injection.MockingTest
Host: tower
don't worry, just a mock
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.726 sec
Running com.airhacks.afterburner.lifecycle.ModelLifecycleTest
Mär 30, 2014 12:36:08 PM com.airhacks.afterburner.views.FXMLView getResourceBundle
INFO: Was not able to find resource bundle: com.airhacks.afterburner.lifecycle.lifecycle
Mär 30, 2014 12:36:08 PM com.airhacks.afterburner.views.FXMLView getResourceBundle
INFO: Was not able to find resource bundle: com.airhacks.afterburner.lifecycle.lifecycle
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 sec
Running com.airhacks.afterburner.views.FXMLViewTest
Mär 30, 2014 12:36:08 PM com.airhacks.afterburner.views.FXMLView getResourceBundle
INFO: Was not able to find resource bundle: non-existing
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec
Running com.airhacks.afterburner.views.TopgunViewTest
Host: tower
Host: tower
Host: tower
Host: tower
Host: ivory tower
Host: tower
Host: tower
Host: tower
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 sec

Results :

Tests run: 20, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
