### PR TITLE
Also add presenter to injectable map

### DIFF
--- a/src/main/java/com/airhacks/afterburner/injection/InjectionProvider.java
+++ b/src/main/java/com/airhacks/afterburner/injection/InjectionProvider.java
@@ -51,6 +51,7 @@ public class InjectionProvider {
     public static Object instantiatePresenter(Class clazz) {
         try {
             Object product = registerExistingAndInject(clazz.newInstance());
+            setModelOrService(product.getClass(), product);
             return product;
         } catch (InstantiationException | IllegalAccessException ex) {
             throw new IllegalStateException("Cannot instantiate view: " + clazz, ex);


### PR DESCRIPTION
Hi Adam,
I have a status bar and a progress bar in one of my presenters. I have to access this progressbar from one of the other presenters.

``` java
...
107     @Inject
108     StandaloneMainPresenter standaloneMainPresenter; // by default this creates a new presenter
...
274         config.put("setProgress", new Function<Double, Void>() {
275 
276             @Override
277             public Void apply(final Double l) {
278                 Platform.runLater(new Runnable() {
279 
280                     @Override
281                     public void run() {
282                         standaloneMainPresenter.progressBar.setProgress(l);
283                         if (l == 1) {
284                             standaloneMainPresenter.rightStatus
285                                     .setText("Done generating Ads");
286                         }
287                     }
288                 });
289                 return null;
290             }
291         });
```

Currently I am adding the presenter containing the progress bar manually.

``` java
...
 54     @Override
 55     public void initialize(URL location, ResourceBundle resources) {
 56         // Add this presenter manually to the injection provider
 57         // TODO: Beg Adam Bien to integrate this in afterburner.fx
 58         InjectionProvider.setModelOrService(getClass(), this);
...
```

It would be nice if this could be added to the afterburner.fx core.
