### PR TITLE
turn async creation pool into daemon threads

### DIFF
--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -52,7 +52,11 @@ public abstract class FXMLView {
     protected ResourceBundle bundle;
     protected final Function<String, Object> injectionContext;
     protected URL resource;
-    protected final static Executor PARENT_CREATION_POOL = Executors.newCachedThreadPool();
+    protected final static Executor PARENT_CREATION_POOL = Executors.newCachedThreadPool(runnable -> {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setDaemon(true);
+        return thread;
+    });
 
     /**
      * Constructs the view lazily (fxml is not loaded) with empty injection


### PR DESCRIPTION
Currently the thread pool in FXMLView is keeping applications alive indefinitely. It either needs to be manually shutdown, e.g., in Application.close() or consist of daemon threads.

Since it's probably reasonable to assume that these threads never do critical work, I've created a tiny patch that modifies the thread factory.
