### PR TITLE
Add support for default injection of attributes defined by interface

### DIFF
--- a/src/test/java/com/airhacks/afterburner/injection/InterfacesTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InterfacesTest.java
@@ -1,0 +1,38 @@
+package com.airhacks.afterburner.injection;
+
+import org.junit.Test;
+
+import com.airhacks.afterburner.injection.Injector;
+import com.airhacks.afterburner.injection.interfaces.InterfacePresenter;
+import com.airhacks.afterburner.injection.interfaces.InterfaceView;
+import com.airhacks.afterburner.injection.interfaces.Ping;
+import com.airhacks.afterburner.injection.interfaces.Pong;
+import com.airhacks.afterburner.injection.interfaces.SimplePing;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class InterfacesTest {
+	@Test
+	public void canBuildAnInterfaceObjectDeclaredInServiceLoader() {
+		Object builtObject = Injector.getDefaultInstanceSupplier().apply(Ping.class);
+		
+		assertThat(builtObject, notNullValue());
+		assertThat(builtObject, instanceOf(SimplePing.class));
+	}
+	
+	@Test (expected=IllegalStateException.class)
+	public void failWhenNoInterfaceImplementationIsFound() {
+		Injector.getDefaultInstanceSupplier().apply(Pong.class);
+	}
+
+	@Test
+	public void canInjectAnInterfaceInAPresenter() {
+		InterfaceView iv = new InterfaceView();
+		InterfacePresenter p = (InterfacePresenter) iv.getPresenter();
+		
+		assertThat(p.getPing(), notNullValue());
+		assertThat(p.getPing(), instanceOf(SimplePing.class));
+	}
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/InterfacePresenter.java
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/InterfacePresenter.java
@@ -1,0 +1,12 @@
+package com.airhacks.afterburner.injection.interfaces;
+
+import javax.inject.Inject;
+
+public class InterfacePresenter {
+	@Inject
+	private Ping p;
+	
+	public Ping getPing() {
+		return p;
+	}
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/InterfaceView.java
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/InterfaceView.java
@@ -1,0 +1,6 @@
+package com.airhacks.afterburner.injection.interfaces;
+
+import com.airhacks.afterburner.views.FXMLView;
+
+public class InterfaceView extends FXMLView {
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/Ping.java
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/Ping.java
@@ -1,0 +1,5 @@
+package com.airhacks.afterburner.injection.interfaces;
+
+public interface Ping {
+	public String ping();
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/Pong.java
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/Pong.java
@@ -1,0 +1,5 @@
+package com.airhacks.afterburner.injection.interfaces;
+
+public interface Pong {
+	public String ping();
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/SimplePing.java
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/SimplePing.java
@@ -1,0 +1,8 @@
+package com.airhacks.afterburner.injection.interfaces;
+
+public class SimplePing implements Ping {
+	@Override
+	public String ping() {
+		return "ping: " + System.currentTimeMillis();
+	}
+}

--- a/src/test/java/com/airhacks/afterburner/injection/interfaces/interface.fxml
+++ b/src/test/java/com/airhacks/afterburner/injection/interfaces/interface.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.layout.BorderPane?>
+
+
+<BorderPane xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8" fx:controller="com.airhacks.afterburner.injection.interfaces.InterfacePresenter">
+	<!-- TODO Add Nodes -->
+</BorderPane>

--- a/src/test/resources/META-INF/services/com.airhacks.afterburner.injection.interfaces.Ping
+++ b/src/test/resources/META-INF/services/com.airhacks.afterburner.injection.interfaces.Ping
@@ -1,0 +1,1 @@
+com.airhacks.afterburner.injection.interfaces.SimplePing


### PR DESCRIPTION
small contribution to provide a default behavior in Afterburner to inject fields which type is an interface. For interfaces only, a delegation to ServiceLoader (standard servie-provider mechanism of JRE) is performed.

Of course this could be achieved externally by setting a home made InstanceSupplier to the Injector.
I found valuable to provide a default behavior for interfaces injection, so here it is.
