### PR TITLE
External di support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ releaseAndUpload.sh
 uploadSnapshot.sh
 .idea
 *.iml
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,22 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>com/airhacks/afterburner/injection/cdi/**.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -87,25 +101,11 @@
                         </goals>
                         <configuration>
                             <artifactSet>
-                                <excludes>
-                                    <exclude>junit:junit</exclude>
-                                </excludes>
+                                <includes>
+                                    <include>javax.inject:javax.inject</include>
+                                </includes>
                             </artifactSet>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.0.201403182114</version>
+                <version>0.7.2.201409121644</version>   <!-- update to get rid of https://github.com/jacoco/jacoco/issues/201 -->
                 <executions>
                     <execution>
                         <goals>
@@ -176,6 +176,83 @@
             </resource>
         </resources>
         <finalName>afterburner</finalName>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- use uptodate version to avoid https://issues.jboss.org/browse/ARQ-282 -->
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>license-maven-plugin</artifactId>
+                                        <versionRange>[1.6,)</versionRange>
+                                        <goals>
+                                            <goal>update-file-header</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.jacoco</groupId>
+                                        <artifactId>jacoco-maven-plugin</artifactId>
+                                        <versionRange>[0.7.0.201403182114,)</versionRange>
+                                        <goals>
+                                            <goal>prepare-agent</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-enforcer-plugin</artifactId>
+                                        <versionRange>[1.2,)</versionRange>
+                                        <goals>
+                                            <goal>enforce</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>build-helper-maven-plugin</artifactId>
+                                        <versionRange>[1.7,)</versionRange>
+                                        <goals>
+                                            <goal>add-test-resource</goal>
+                                            <goal>add-test-source</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
     <scm>
         <connection>scm:git:git@github.com:AdamBien/afterburner.fx.git</connection>
@@ -188,4 +265,118 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <profiles>
+        <profile>
+            <!-- signing in a profile allows external contributors to skip its execution -->
+            <id>signature</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cdi-weld</id>
+            <activation>
+                <property>
+                    <name>cdi</name>
+                    <value>weld</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>add-weld-sources</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/cdi/weld/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>add-weld-resources</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>add-test-resource</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/test/cdi/weld/java</directory>
+                                            <includes>
+                                                <include>**/*.fxml</include>
+                                                <include>**/*.css</include>
+                                                <include>**/*.properties</include>
+                                            </includes>
+                                        </resource>
+                                        <resource>
+                                            <directory>src/test/cdi/weld/resources</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cdi-weld-tests</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>com/airhacks/afterburner/injection/cdi/**.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se</artifactId>
+                    <version>2.1.2.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                    <version>1.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -111,8 +111,10 @@ public class Injector {
         Object product = modelsAndServices.get(clazz);
         if (product == null) {
         	Object instance = instanceSupplier.instanciate(clazz);
-            product = instanceSupplier.isInjectionAware()?instance:injectAndInitialize(instance);
-            modelsAndServices.putIfAbsent(clazz, product);
+        	product = instanceSupplier.isInjectionAware()?instance:injectAndInitialize(instance);
+        	if (!instanceSupplier.isScopeAware()) {
+        		modelsAndServices.putIfAbsent(clazz, product);
+        	}
         }
         return product;
     }
@@ -244,7 +246,20 @@ public class Injector {
     
     @FunctionalInterface
     public static interface InstanceProvider {
+    	/**
+    	 * Express the fact that the InstanceProvider also handles injection & javax.inject lifecycle callbacks
+    	 * @return true it the InstanceProvider handles injection & lifecycle callbacks, false otherwise
+    	 */
     	public default boolean isInjectionAware() {
+    		return false;
+    	}
+    	
+    	/**
+    	 * Tells if the InjectionProvider handles javax.inject.Scope and thus if the InjectionProvider is able to "cache" instances
+    	 * depending on their scope creation
+    	 * @return true it the InstanceProvider is Scope aware, false otherwise
+    	 */
+    	public default boolean isScopeAware() {
     		return false;
     	}
     	

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/CDIManualTest.java
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/CDIManualTest.java
@@ -1,0 +1,92 @@
+package com.airhacks.afterburner.injection.cdi;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.airhacks.afterburner.injection.Injector;
+
+public class CDIManualTest {
+    private static Weld weld;
+    private static WeldContainer container;
+    
+	@BeforeClass
+    public static void initializeWeld() {
+        weld = new Weld();
+        container = weld.initialize();
+    }
+    
+    @AfterClass
+    public static void shutdownWeld() {
+        weld.shutdown();
+    }	
+
+	@Before
+	public void initCDIInAfterBurner() {
+		Injector.setInstanceSupplier(new Injector.InstanceProvider() {
+			@Override
+			public boolean isInjectionAware() {
+				// CDI realizes injections
+				return true;
+			}
+			@Override
+			public boolean isScopeAware() {
+				// CDI knows about scopes
+				return true;
+			}
+			@Override
+			public Object instanciate(Class<?> c) {
+				return container.instance().select(c).get();
+			}
+		});
+	}
+	
+	@After
+	public void resetCDITests() {
+		Injector.forgetAll();
+	}
+	
+	@Test
+	public void checkCDIRespectsSingletonScope() {
+		NormalCDIPresenter p = (NormalCDIPresenter) new NormalCDIView().getPresenter();
+		
+		// Let's as the DI container for some objects injected in the presenter
+        Sun theSun = container.instance().select(Sun.class).get();
+        Star aStar = container.instance().select(Star.class).get();
+
+        // The sun is a Singleton and has to be unique
+		assertThat(p.getTheSun(), is(theSun));
+		
+        // The sun is a Singleton and has to be unique
+		assertThat(p.getaStar(), not(is(aStar)));
+	}
+}

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/NormalCDIPresenter.java
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/NormalCDIPresenter.java
@@ -1,0 +1,38 @@
+package com.airhacks.afterburner.injection.cdi;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import javax.inject.Inject;
+
+public class NormalCDIPresenter {
+	@Inject
+	private Sun theSun;
+	@Inject
+	private Star aStar;
+	
+	public Sun getTheSun() {
+		return theSun;
+	}
+	public Star getaStar() {
+		return aStar;
+	}
+}

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/NormalCDIView.java
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/NormalCDIView.java
@@ -1,0 +1,28 @@
+package com.airhacks.afterburner.injection.cdi;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.airhacks.afterburner.views.FXMLView;
+
+public class NormalCDIView extends FXMLView {
+
+}

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/Star.java
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/Star.java
@@ -1,0 +1,25 @@
+package com.airhacks.afterburner.injection.cdi;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+public class Star {
+}

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/Sun.java
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/Sun.java
@@ -1,0 +1,28 @@
+package com.airhacks.afterburner.injection.cdi;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Sun {
+}

--- a/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/normalcdi.fxml
+++ b/src/test/cdi/weld/java/com/airhacks/afterburner/injection/cdi/normalcdi.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.BorderPane?>
+
+<BorderPane xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.airhacks.afterburner.injection.cdi.NormalCDIPresenter">
+</BorderPane>
+

--- a/src/test/cdi/weld/resources/META-INF/beans.xml
+++ b/src/test/cdi/weld/resources/META-INF/beans.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  afterburner.fx
+  %%
+  Copyright (C) 2013 - 2014 Adam Bien
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:weld="http://jboss.org/schema/weld/beans" 
+       xsi:schemaLocation="
+          http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd
+          http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+    <weld:scan>
+        <weld:include name="com.airhacks.afterburner.injection.cdi.*">
+        </weld:include>
+    </weld:scan>
+</beans>

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -24,17 +24,26 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
 import static org.hamcrest.CoreMatchers.is;
+
 import org.junit.After;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import static org.mockito.Matchers.anyString;
+
 import org.mockito.Mockito;
+
+import com.airhacks.afterburner.injection.Injector.InstanceProvider;
+
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -97,7 +106,7 @@ public class InjectorTest {
 
     @Test
     public void setInstanceSupplier() {
-        Function<Class, Object> provider = t -> Mockito.mock(t);
+        InstanceProvider provider = t -> Mockito.mock(t);
         Injector.setInstanceSupplier(provider);
         Object mock = Injector.instantiateModelOrService(Model.class);
         assertTrue(mock.getClass().getName().contains("ByMockito"));

--- a/src/test/java/com/airhacks/afterburner/injection/MockingTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/MockingTest.java
@@ -48,13 +48,18 @@ package com.airhacks.afterburner.injection;
  * limitations under the License.
  * #L%
  */
+import com.airhacks.afterburner.injection.Injector.InstanceProvider;
 import com.airhacks.afterburner.topgun.GunService;
 import com.airhacks.afterburner.topgun.TopgunPresenter;
 import com.airhacks.afterburner.topgun.TopgunView;
+
 import java.util.function.Function;
+
 import org.junit.After;
 import org.junit.Assert;
+
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -85,7 +90,7 @@ public class MockingTest {
 
     @Test
     public void setMockViaInstanceSupplier() {
-        Function<Class, Object> provider = (t) -> {
+        InstanceProvider provider = (t) -> {
             if (t.isAssignableFrom(GunService.class)) {
                 return Mockito.mock(t);
             } else {


### PR DESCRIPTION
Adam,

find enclosed the modifications I did in order to introduce an external DI, weld in my case.
I tried to keep it source code compatible even with introduction of the functional interface `Injector.InstanceProvider`.
The weld tests are restricted to the usage of the _"cdi-weld"_ maven profile.

Do not hesitate to come back to me if needed.

Matthieu