### PR TITLE
Implemented @Singleton support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <groupId>com.airhacks</groupId>
     <artifactId>afterburner.fx</artifactId>
-    <version>1.6.3-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>afterburner.fx</name>
@@ -176,20 +176,22 @@
                 </includes>
             </resource>
             <resource>
-                <directory>src/test/java</directory>
-                <includes>
-                    <include>**/*.fxml</include>
-                    <include>**/*.css</include>
-                    <include>**/*.properties</include>
-                </includes>
-            </resource>
-            <resource>
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>**/*.xml</include>
                 </includes>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/java</directory>
+                <includes>
+                    <include>**/*.fxml</include>
+                    <include>**/*.css</include>
+                    <include>**/*.properties</include>
+                </includes>
+            </testResource>
+        </testResources>
         <finalName>afterburner</finalName>
     </build>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,15 @@
     </developers>
     <dependencies>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Test scope dependencies -->
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
@@ -47,10 +56,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-            <scope>compile</scope>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se</artifactId>
+            <version>2.2.14.Final</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -19,29 +19,24 @@ package com.airhacks.afterburner.injection;
  * limitations under the License.
  * #L%
  */
+
 import com.airhacks.afterburner.configuration.Configurator;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 /**
- *
  * @author adam-bien.com
  * @author Mewes Kochheim
  */
@@ -49,106 +44,27 @@ public class Injector {
 
     private static final Map<Class<?>, Object> modelsAndServices = new WeakHashMap<>();
     private static final Set<Object> presenters = Collections.newSetFromMap(new WeakHashMap<>());
-
+    private static final Configurator configurator = new Configurator();
     private static Function<Class<?>, Object> instanceSupplier = getDefaultInstanceSupplier();
-
     private static Consumer<String> LOG = getDefaultLogger();
 
-    private static final Configurator configurator = new Configurator();
+    // Public
 
-    
-	public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
-		@SuppressWarnings("unchecked")
-		T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz));
-        //after the regular, conventional initialization and injection, perform postinjection
-        Field[] fields = clazz.getDeclaredFields();
-        for (final Field field : fields) {
-            if (field.isAnnotationPresent(Inject.class)) {
-                final String fieldName = field.getName();
-                final Object value = injectionContext.apply(fieldName);
-                if (value != null) {
-                    injectIntoField(field, presenter, value);
-                }
-            }
-        }
-        return presenter;
+    public static void forgetAll() {
+        Collection<Object> values = modelsAndServices.values();
+        values.stream().forEach(Injector::destroy);
+        presenters.stream().forEach(Injector::destroy);
+        presenters.clear();
+        modelsAndServices.clear();
+        resetInstanceSupplier();
+        resetConfigurationSource();
     }
 
-    public static <T> T instantiatePresenter(Class<T> clazz) {
-        return instantiatePresenter(clazz, f -> null);
+    public static Consumer<String> getDefaultLogger() {
+        return l -> {};
     }
 
-    public static void setInstanceSupplier(Function<Class<?>, Object> instanceSupplier) {
-        Injector.instanceSupplier = instanceSupplier;
-    }
-
-    public static void setLogger(Consumer<String> logger) {
-        LOG = logger;
-    }
-
-    public static void setConfigurationSource(Function<Object, Object> configurationSupplier) {
-        configurator.set(configurationSupplier);
-    }
-
-    public static void resetInstanceSupplier() {
-        instanceSupplier = getDefaultInstanceSupplier();
-    }
-
-    public static void resetConfigurationSource() {
-        configurator.forgetAll();
-    }
-
-    /**
-     * Caches the passed presenter internally and injects all fields
-     *
-     * @param instance An already existing (legacy) presenter interesting in
-     * injection
-     * @return presenter with injected fields
-     */
-    public static <T> T registerExistingAndInject(T instance) {
-        T product = injectAndInitialize(instance);
-        presenters.add(product);
-        return product;
-    }
-
-    /**
-     * Mimics the original behavior to increase backward compatibility
-     *
-     * @param clazz The class of the desired instance
-     * @return Instance with injected fields
-     */
-    public static <T> T instantiateModelOrService(Class<T> clazz) {
-        return instantiateModelOrService(clazz, true);
-    }
-
-	@SuppressWarnings("unchecked")
-	public static <T> T instantiateModelOrService(Class<T> clazz, boolean singleton) {
-		T product = (T) modelsAndServices.get(clazz);
-        if (product == null) {
-            product = injectAndInitialize((T)instanceSupplier.apply(clazz));
-            if (singleton) {
-                modelsAndServices.putIfAbsent(clazz, product);
-            }
-        }
-        return clazz.cast(product);
-    }
-
-    public static <T> void setModelOrService(Class<T> clazz, T instance) {
-        modelsAndServices.put(clazz, instance);
-    }
-
-    static <T> T injectAndInitialize(T product) {
-        injectMembers(product);
-        initialize(product);
-        return product;
-    }
-
-    static void injectMembers(final Object instance) {
-        Class<? extends Object> clazz = instance.getClass();
-        injectMembers(clazz, instance);
-    }
-
-    public static void injectMembers(Class<? extends Object> clazz, final Object instance) throws SecurityException {
+    public static void injectMembers(Class<?> clazz, final Object instance, Function<String, Object> injectionContext) throws SecurityException {
         LOG.accept("Injecting members for class " + clazz + " and instance " + instance);
         Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {
@@ -160,7 +76,7 @@ public class Injector {
                 LOG.accept("Value returned by configurator is: " + value);
                 if (value == null && isNotPrimitiveOrString(type)) {
                     LOG.accept("Field is not a JDK class");
-                    value = instantiateModelOrService(type, type.isAnnotationPresent(Singleton.class));
+                    value = instantiateModelOrService(type, injectionContext);
                 }
                 if (value != null) {
                     LOG.accept("Value is a primitive, injecting...");
@@ -168,14 +84,119 @@ public class Injector {
                 }
             }
         }
-        Class<? extends Object> superclass = clazz.getSuperclass();
+        Class<?> superclass = clazz.getSuperclass();
         if (superclass != null) {
             LOG.accept("Injecting members of: " + superclass);
-            injectMembers(superclass, instance);
+            injectMembers(superclass, instance, injectionContext);
         }
     }
 
-	static void injectIntoField(final Field field, final Object instance, final Object target) {
+    public static void injectMembers(Class<?> clazz, final Object instance) throws SecurityException {
+        injectMembers(clazz, instance, f -> null);
+    }
+
+    public static <T> T instantiateModelOrService(Class<T> clazz, Function<String, Object> injectionContext) {
+        Object product = modelsAndServices.get(clazz);
+        if (product == null) {
+            product = injectAndInitialize(instanceSupplier.apply(clazz), injectionContext);
+            if (clazz.isAnnotationPresent(Singleton.class)) {
+                modelsAndServices.putIfAbsent(clazz, product);
+            }
+        }
+        return clazz.cast(product);
+    }
+
+    public static <T> T instantiateModelOrService(Class<T> clazz) {
+        return instantiateModelOrService(clazz, f -> null);
+    }
+
+    public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
+        @SuppressWarnings("unchecked")
+        T presenter = registerExistingAndInject((T) instanceSupplier.apply(clazz));
+        //after the regular, conventional initialization and injection, perform postinjection
+        applyInjectionContext(presenter, injectionContext);
+        return presenter;
+    }
+
+    public static <T> T instantiatePresenter(Class<T> clazz) {
+        return instantiatePresenter(clazz, f -> null);
+    }
+
+    public static <T> T registerExistingAndInject(T instance, Function<String, Object> injectionContext) {
+        T product = injectAndInitialize(instance, injectionContext);
+        presenters.add(product);
+        return product;
+    }
+
+    public static <T> T registerExistingAndInject(T instance) {
+        return registerExistingAndInject(instance, f -> null);
+    }
+
+    public static void resetConfigurationSource() {
+        configurator.forgetAll();
+    }
+
+    public static void resetInstanceSupplier() {
+        instanceSupplier = getDefaultInstanceSupplier();
+    }
+
+    public static void setConfigurationSource(Function<Object, Object> configurationSupplier) {
+        configurator.set(configurationSupplier);
+    }
+
+    public static void setInstanceSupplier(Function<Class<?>, Object> instanceSupplier) {
+        Injector.instanceSupplier = instanceSupplier;
+    }
+
+    public static void setLogger(Consumer<String> logger) {
+        LOG = logger;
+    }
+
+    public static <T> void setModelOrService(Class<T> clazz, T instance) {
+        modelsAndServices.put(clazz, instance);
+    }
+
+    // Package private
+
+    static <T> T applyInjectionContext(T instance, Function<String, Object> injectionContext) {
+        Field[] fields = instance.getClass().getDeclaredFields();
+        for (final Field field : fields) {
+            if (field.isAnnotationPresent(Inject.class)) {
+                final String fieldName = field.getName();
+                final Object value = injectionContext.apply(fieldName);
+                if (value != null) {
+                    injectIntoField(field, instance, value);
+                }
+            }
+        }
+        return instance;
+    }
+
+    static void destroy(Object instance) {
+        invokeMethodWithAnnotation(instance.getClass(), instance, PreDestroy.class);
+    }
+
+    static Function<Class<?>, Object> getDefaultInstanceSupplier() {
+        return (c) -> {
+            try {
+                return c.newInstance();
+            } catch (InstantiationException | IllegalAccessException ex) {
+                throw new IllegalStateException("Cannot instantiate view: " + c, ex);
+            }
+        };
+    }
+
+    static void initialize(Object instance) {
+        invokeMethodWithAnnotation(instance.getClass(), instance, PostConstruct.class);
+    }
+
+    static <T> T injectAndInitialize(T product, Function<String, Object> injectionContext) {
+        injectMembers(product.getClass(), product, injectionContext);
+        initialize(product);
+        return product;
+    }
+
+    static void injectIntoField(final Field field, final Object instance, final Object target) {
         AccessController.doPrivileged((PrivilegedAction<?>) () -> {
             boolean wasAccessible = field.isAccessible();
             try {
@@ -190,27 +211,15 @@ public class Injector {
         });
     }
 
-    static void initialize(Object instance) {
-        Class<? extends Object> clazz = instance.getClass();
-        invokeMethodWithAnnotation(clazz, instance, PostConstruct.class
-        );
-    }
-
-    static void destroy(Object instance) {
-        Class<? extends Object> clazz = instance.getClass();
-        invokeMethodWithAnnotation(clazz, instance, PreDestroy.class
-        );
-    }
-
     static void invokeMethodWithAnnotation(Class<?> clazz, final Object instance, final Class<? extends Annotation> annotationClass) throws IllegalStateException, SecurityException {
         Method[] declaredMethods = clazz.getDeclaredMethods();
         for (final Method method : declaredMethods) {
             if (method.isAnnotationPresent(annotationClass)) {
-                AccessController.doPrivileged((PrivilegedAction<?>) () -> {
+                AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
                     boolean wasAccessible = method.isAccessible();
                     try {
                         method.setAccessible(true);
-                        return method.invoke(instance, new Object[]{});
+                        return method.invoke(instance);
                     } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
                         throw new IllegalStateException("Problem invoking " + annotationClass + " : " + method, ex);
                     } finally {
@@ -225,36 +234,7 @@ public class Injector {
         }
     }
 
-    public static void forgetAll() {
-        Collection<Object> values = modelsAndServices.values();
-        values.stream().forEach((object) -> {
-            destroy(object);
-        });
-        presenters.stream().forEach((object) -> {
-            destroy(object);
-        });
-        presenters.clear();
-        modelsAndServices.clear();
-        resetInstanceSupplier();
-        resetConfigurationSource();
-    }
-
-    static Function<Class<?>, Object> getDefaultInstanceSupplier() {
-        return (c) -> {
-            try {
-                return c.newInstance();
-            } catch (InstantiationException | IllegalAccessException ex) {
-                throw new IllegalStateException("Cannot instantiate view: " + c, ex);
-            }
-        };
-    }
-
-    public static Consumer<String> getDefaultLogger() {
-        return l -> {
-        };
-    }
-
-    private static boolean isNotPrimitiveOrString(Class<?> type) {
+    static boolean isNotPrimitiveOrString(Class<?> type) {
         return !type.isPrimitive() && !type.isAssignableFrom(String.class);
     }
 }

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -173,11 +173,17 @@ public class Injector {
 
                 // Try injection context
                 if (field.isAnnotationPresent(Named.class)) {
+                    // Inject by name
                     Named named = field.getAnnotation(Named.class);
                     value = injectionContext.apply(named.value());
                 }
                 if (value == null) {
+                    // Inject by field name
                     value = injectionContext.apply(field.getName());
+                }
+                if (value == null) {
+                    // Inject by type
+                    value = injectionContext.apply(field.getType().getName());
                 }
 
                 // Try configurator

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -25,6 +25,7 @@ import com.airhacks.afterburner.configuration.Configurator;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -168,9 +169,16 @@ public class Injector {
                 LOG.accept("Field annotated with @Inject found: " + field);
                 Class<?> type = field.getType();
                 String key = field.getName();
+                Object value = null;
 
                 // Try injection context
-                Object value = injectionContext.apply(field.getName());
+                if (field.isAnnotationPresent(Named.class)) {
+                    Named named = field.getAnnotation(Named.class);
+                    value = injectionContext.apply(named.value());
+                }
+                if (value == null) {
+                    value = injectionContext.apply(field.getName());
+                }
 
                 // Try configurator
                 if (value == null) {

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -82,12 +82,12 @@ public class Injector {
         return injectAndInitialize(instance, f -> null);
     }
 
-    public static <T> T inject(final T instance, Function<String, Object> injectionContext) throws SecurityException {
+    public static <T> T inject(final T instance, Function<String, Object> injectionContext) {
         injectMembers(instance.getClass(), instance, injectionContext);
         return instance;
     }
 
-    public static <T> T inject(final T instance) throws SecurityException {
+    public static <T> T inject(final T instance) {
         return inject(instance, f -> null);
     }
 
@@ -97,18 +97,6 @@ public class Injector {
             instance = injectAndInitialize(instanceSupplier.apply(clazz), injectionContext);
             if (clazz.isAnnotationPresent(Singleton.class)) {
                 singletons.putIfAbsent(clazz, instance);
-            }
-        } else {
-            // Apply new injection context which may overrides previous contexts
-            Field[] fields = clazz.getDeclaredFields();
-            for (final Field field : fields) {
-                if (field.isAnnotationPresent(Inject.class)) {
-                    final String fieldName = field.getName();
-                    final Object value = injectionContext.apply(fieldName);
-                    if (value != null) {
-                        injectIntoField(field, instance, value);
-                    }
-                }
             }
         }
         return clazz.cast(instance);
@@ -172,7 +160,7 @@ public class Injector {
         });
     }
 
-    static void injectMembers(Class<?> clazz, final Object instance, Function<String, Object> injectionContext) throws SecurityException {
+    static void injectMembers(Class<?> clazz, final Object instance, Function<String, Object> injectionContext) {
         LOG.accept("Injecting members for class " + clazz + " and instance " + instance);
         Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -51,17 +51,22 @@ public class Injector {
     // Public
 
     public static void forgetAll() {
-        Collection<Object> values = singletons.values();
-        values.stream().forEach(Injector::destroy);
+        singletons.values().stream().forEach(Injector::destroy);
+        singletons.clear();
+
         presenters.stream().forEach(Injector::destroy);
         presenters.clear();
-        singletons.clear();
+
         resetInstanceSupplier();
         resetConfigurationSource();
     }
 
     public static Consumer<String> getDefaultLogger() {
         return l -> {};
+    }
+
+    public static <T> void addSingleton(Class<T> clazz, T instance) {
+        singletons.put(clazz, instance);
     }
 
     public static <T> T initialize(final T instance) {
@@ -124,14 +129,6 @@ public class Injector {
         return instantiatePresenter(clazz, f -> null);
     }
 
-    public static void resetConfigurationSource() {
-        configurator.forgetAll();
-    }
-
-    public static void resetInstanceSupplier() {
-        instanceSupplier = getDefaultInstanceSupplier();
-    }
-
     public static void setConfigurationSource(Function<Object, Object> configurationSupplier) {
         configurator.set(configurationSupplier);
     }
@@ -142,10 +139,6 @@ public class Injector {
 
     public static void setLogger(Consumer<String> logger) {
         LOG = logger;
-    }
-
-    public static <T> void setModelOrService(Class<T> clazz, T instance) {
-        singletons.put(clazz, instance);
     }
 
     // Package private
@@ -239,5 +232,13 @@ public class Injector {
 
     static boolean isInstantiatable(Class<?> type) {
         return !type.isPrimitive() && !type.isAssignableFrom(String.class);
+    }
+
+    static void resetConfigurationSource() {
+        configurator.forgetAll();
+    }
+
+    static void resetInstanceSupplier() {
+        instanceSupplier = getDefaultInstanceSupplier();
     }
 }

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -188,7 +188,7 @@ public abstract class FXMLView {
      * @param presenterConsumer listener for the presenter construction
      */
     public void getPresenter(Consumer<Object> presenterConsumer) {
-        this.presenterProperty.addListener((ObservableValue<? extends Object> o, Object oldValue, Object newValue) -> {
+        this.presenterProperty.addListener((ObservableValue<?> o, Object oldValue, Object newValue) -> {
             presenterConsumer.accept(newValue);
         });
     }

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -86,7 +86,7 @@ public abstract class FXMLView {
 
     FXMLLoader loadSynchronously(final URL resource, ResourceBundle bundle, final String conventionalName) throws IllegalStateException {
         final FXMLLoader loader = new FXMLLoader(resource, bundle);
-        loader.setControllerFactory((Class<?> p) -> Injector.instantiatePresenter(p, this.injectionContext));
+        loader.setControllerFactory((Class<?> p) -> Injector.instantiate(p, this.injectionContext));
         try {
             loader.load();
         } catch (IOException ex) {

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -39,6 +39,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.util.Callback;
 
 /**
  * @author adam-bien.com
@@ -46,6 +47,7 @@ import javafx.scene.Parent;
 public abstract class FXMLView {
 
     public final static String DEFAULT_ENDING = "view";
+
     protected ObjectProperty<Object> presenterProperty;
     protected FXMLLoader fxmlLoader;
     protected String bundleName;
@@ -86,7 +88,7 @@ public abstract class FXMLView {
 
     FXMLLoader loadSynchronously(final URL resource, ResourceBundle bundle, final String conventionalName) throws IllegalStateException {
         final FXMLLoader loader = new FXMLLoader(resource, bundle);
-        loader.setControllerFactory((Class<?> p) -> Injector.instantiate(p, this.injectionContext));
+        loader.setControllerFactory(getControllerFactory());
         try {
             loader.load();
         } catch (IOException ex) {
@@ -100,6 +102,16 @@ public abstract class FXMLView {
             this.fxmlLoader = this.loadSynchronously(resource, bundle, bundleName);
             this.presenterProperty.set(this.fxmlLoader.getController());
         }
+    }
+
+    /**
+     * Returns the controller factory for FXMLLoader.
+     * Override this method to change the dependency injection implementation.
+     *
+     * @return The controller factory
+     */
+    public Callback<Class<?>, Object> getControllerFactory() {
+        return (Class<?> p) -> Injector.instantiate(p, injectionContext);
     }
 
     /**

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -22,8 +22,8 @@ package com.airhacks.afterburner.views;
 import com.airhacks.afterburner.injection.Injector;
 import java.io.IOException;
 import java.net.URL;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+import java.util.*;
+
 import static java.util.ResourceBundle.getBundle;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -61,18 +61,33 @@ public abstract class FXMLView {
     });
 
     /**
-     * Constructs the view lazily (fxml is not loaded) with empty injection
-     * context.
+     * Constructs the view lazily (fxml is not loaded).
      */
     public FXMLView() {
         this(f -> null);
     }
 
     /**
+     * Constructs the view lazily (fxml is not loaded).
      *
-     * @param injectionContext the function is used as a injection source.
-     * Values matching for the keys are going to be used for injection into the
-     * corresponding presenter.
+     * @param injectedValues A list of values used as a injection source. Values matching a type are going to be used
+     *                       for injection into the corresponding presenter all its injected members.
+     */
+    public FXMLView(Object... injectedValues) {
+        Map<String, Object> injectionMap = new HashMap<>();
+        for (Object injectedValue : injectedValues) {
+            injectionMap.put(injectedValue.getClass().getName(), injectedValue);
+        }
+        this.injectionContext = injectionMap::get;
+        this.init(getClass(), getFXMLName());
+    }
+
+    /**
+     * Constructs the view lazily (fxml is not loaded).
+     *
+     * @param injectionContext the function is used as a injection source. Values matching a name, a field name or a
+     *                         type are going to be used for injection into the corresponding presenter all its
+     *                         injected members.
      */
     public FXMLView(Function<String, Object> injectionContext) {
         this.injectionContext = injectionContext;

--- a/src/test/java/com/airhacks/afterburner/configuration/ConfiguratorTest.java
+++ b/src/test/java/com/airhacks/afterburner/configuration/ConfiguratorTest.java
@@ -65,7 +65,7 @@ public class ConfiguratorTest {
 
     @Test
     public void loggerPassed() {
-        this.cut.setLogger((l) -> System.out.println(l));
+        this.cut.setLogger(System.out::println);
     }
 
     @Test

--- a/src/test/java/com/airhacks/afterburner/injection/Boundary.java
+++ b/src/test/java/com/airhacks/afterburner/injection/Boundary.java
@@ -20,12 +20,14 @@ package com.airhacks.afterburner.injection;
  * #L%
  */
 
+import javax.inject.Singleton;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
  * @author adam-bien.com
  */
+@Singleton
 public class Boundary {
 
     static AtomicInteger INSTANCE_COUNT = new AtomicInteger(0);

--- a/src/test/java/com/airhacks/afterburner/injection/Boundary.java
+++ b/src/test/java/com/airhacks/afterburner/injection/Boundary.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Singleton
 public class Boundary {
 
-    static AtomicInteger INSTANCE_COUNT = new AtomicInteger(0);
+    final static AtomicInteger INSTANCE_COUNT = new AtomicInteger(0);
 
     public Boundary() {
         INSTANCE_COUNT.incrementAndGet();

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -43,33 +43,33 @@ public class InjectorTest {
 
 	@Test
     public void injection() {
-        View view = Injector.instantiatePresenter(View.class);
+        View view = Injector.instantiate(View.class);
         Boundary boundary = view.getBoundary();
         assertNotNull(boundary);
         assertThat(boundary.getNumberOfInstances(), is(1));
         @SuppressWarnings("unused")
-        AnotherView another = Injector.instantiatePresenter(AnotherView.class);
+        AnotherView another = Injector.instantiate(AnotherView.class);
         assertThat(boundary.getNumberOfInstances(), is(1));
     }
 
     @Test
     public void perInstanceInitialization() {
-        View first = Injector.instantiatePresenter(View.class);
-        View second = Injector.instantiatePresenter(View.class);
+        View first = Injector.instantiate(View.class);
+        View second = Injector.instantiate(View.class);
         assertNotSame(first, second);
     }
 
     @Test
     public void forgetAllPresenters() {
-        Presenter first = Injector.instantiatePresenter(Presenter.class);
+        Presenter first = Injector.instantiate(Presenter.class);
         Injector.forgetAll();
-        Presenter second = Injector.instantiatePresenter(Presenter.class);
+        Presenter second = Injector.instantiate(Presenter.class);
         assertNotSame(first, second);
     }
 
     @Test
     public void injectionContextWithEmptyContext() {
-        PresenterWithField withField = Injector.instantiatePresenter(PresenterWithField.class);
+        PresenterWithField withField = Injector.instantiate(PresenterWithField.class);
         assertNull(withField.getName());
         Injector.forgetAll();
     }
@@ -79,7 +79,7 @@ public class InjectorTest {
         String expected = "hello duke";
         Map<String, Object> injectionContext = new HashMap<>();
         injectionContext.put("name", expected);
-        PresenterWithField withField = Injector.instantiatePresenter(PresenterWithField.class, injectionContext::get);
+        PresenterWithField withField = Injector.instantiate(PresenterWithField.class, injectionContext::get);
         assertThat(withField.getName(), is(expected));
         Injector.forgetAll();
     }
@@ -116,7 +116,7 @@ public class InjectorTest {
 
     @Test
     public void productDestruction() {
-        DestructibleProduct product = Injector.instantiatePresenter(DestructibleProduct.class);
+        DestructibleProduct product = Injector.instantiate(DestructibleProduct.class);
         assertFalse(product.isDestroyed());
         Injector.forgetAll();
         assertTrue(product.isDestroyed());

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -86,9 +86,9 @@ public class InjectorTest {
 
     @Test
     public void forgetAllModels() {
-        Model first = Injector.instantiateModelOrService(Model.class);
+        Model first = Injector.instantiate(Model.class);
         Injector.forgetAll();
-        Model second = Injector.instantiateModelOrService(Model.class);
+        Model second = Injector.instantiate(Model.class);
         assertNotSame(first, second);
     }
 
@@ -96,20 +96,21 @@ public class InjectorTest {
     public void setInstanceSupplier() {
         Function<Class<?>, Object> provider = Mockito::mock;
         Injector.setInstanceSupplier(provider);
-        Object mock = Injector.instantiateModelOrService(Model.class);
+        Object mock = Injector.instantiate(Model.class);
         assertTrue(mock.getClass().getName().contains("ByMockito"));
         Injector.resetInstanceSupplier();
     }
 
     @Test
     public void productInitialization() {
-        InitializableProduct product = Injector.instantiatePresenter(InitializableProduct.class);
+        InitializableProduct product = Injector.instantiate(InitializableProduct.class);
         assertTrue(product.isInitialized());
     }
 
     @Test
     public void existingPresenterInitialization() {
-        InitializableProduct product = Injector.registerExistingAndInject(new InitializableProduct());
+        InitializableProduct product = new InitializableProduct();
+        Injector.injectAndInitialize(product);
         assertTrue(product.isInitialized());
     }
 

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -19,6 +19,11 @@ package com.airhacks.afterburner.injection;
  * limitations under the License.
  * #L%
  */
+
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,25 +31,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
-
-import org.junit.After;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
-import static org.mockito.Matchers.anyString;
-
-import org.mockito.Mockito;
-
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  *
@@ -106,7 +94,7 @@ public class InjectorTest {
 
     @Test
     public void setInstanceSupplier() {
-        Function<Class<?>, Object> provider = t -> Mockito.mock(t);
+        Function<Class<?>, Object> provider = Mockito::mock;
         Injector.setInstanceSupplier(provider);
         Object mock = Injector.instantiateModelOrService(Model.class);
         assertTrue(mock.getClass().getName().contains("ByMockito"));
@@ -137,14 +125,14 @@ public class InjectorTest {
     public void systemPropertiesInjectionOfExistingProperty() {
         final String expected = "42";
         System.setProperty("shouldExist", expected);
-        SystemProperties systemProperties = Injector.injectAndInitialize(new SystemProperties());
+        SystemProperties systemProperties = Injector.injectAndInitialize(new SystemProperties(), f -> null);
         String actual = systemProperties.getShouldExist();
         assertThat(actual, is(expected));
     }
 
     @Test
     public void systemPropertiesInjectionOfNotExistingProperty() {
-        SystemProperties systemProperties = Injector.injectAndInitialize(new SystemProperties());
+        SystemProperties systemProperties = Injector.injectAndInitialize(new SystemProperties(), f -> null);
         String actual = systemProperties.getDoesNotExists();
         assertNull(actual);
     }
@@ -153,7 +141,7 @@ public class InjectorTest {
     public void longInjectionWithCustomProvider() {
         long expected = 42;
         Injector.setConfigurationSource((f) -> expected);
-        CustomProperties systemProperties = Injector.injectAndInitialize(new CustomProperties());
+        CustomProperties systemProperties = Injector.injectAndInitialize(new CustomProperties(), f -> null);
         long actual = systemProperties.getNumber();
         assertThat(actual, is(expected));
     }
@@ -161,7 +149,7 @@ public class InjectorTest {
     @Test
     public void longInjectionOfNotExistingProperty() {
         long expected = 0;
-        CustomProperties systemProperties = Injector.injectAndInitialize(new CustomProperties());
+        CustomProperties systemProperties = Injector.injectAndInitialize(new CustomProperties(), f -> null);
         long actual = systemProperties.getNumber();
         assertThat(actual, is(expected));
     }
@@ -170,14 +158,14 @@ public class InjectorTest {
     public void dateInjectionWithCustomProvider() {
         Date expected = new Date();
         Injector.setConfigurationSource((f) -> expected);
-        DateProperties systemProperties = Injector.injectAndInitialize(new DateProperties());
+        DateProperties systemProperties = Injector.injectAndInitialize(new DateProperties(), f -> null);
         Date actual = systemProperties.getCustomDate();
         assertThat(actual, is(expected));
     }
 
     @Test
     public void dateInjectionOfNotExistingProperty() {
-        DateProperties systemProperties = Injector.injectAndInitialize(new DateProperties());
+        DateProperties systemProperties = Injector.injectAndInitialize(new DateProperties(), f -> null);
         Date actual = systemProperties.getCustomDate();
         //java.util.Date is not a primitive, or String. Can be created and injected.
         assertNotNull(actual);
@@ -188,7 +176,7 @@ public class InjectorTest {
 		@SuppressWarnings("unchecked")
         Consumer<String> logger = mock(Consumer.class);
         Injector.setLogger(logger);
-        Injector.injectAndInitialize(new DateProperties());
+        Injector.injectAndInitialize(new DateProperties(), f -> null);
         verify(logger, atLeastOnce()).accept(anyString());
     }
 

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -37,10 +37,10 @@ import static org.mockito.Mockito.*;
 /**
  *
  * @author adam-bien.com
+ * @author Mewes Kochheim
  */
 public class InjectorTest {
 
-    
 	@Test
     public void injection() {
         View view = Injector.instantiatePresenter(View.class);

--- a/src/test/java/com/airhacks/afterburner/injection/MockingTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/MockingTest.java
@@ -66,7 +66,7 @@ public class MockingTest {
 
     @Test
     public void mockIsActive() {
-        Injector.setModelOrService(GunService.class, new GunService() {
+        Injector.addSingleton(GunService.class, new GunService() {
 
             @Override
             public String fireAndForget() {

--- a/src/test/java/com/airhacks/afterburner/injection/context/InitializableEntity.java
+++ b/src/test/java/com/airhacks/afterburner/injection/context/InitializableEntity.java
@@ -1,0 +1,43 @@
+package com.airhacks.afterburner.injection.context;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javax.inject.Inject;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InitializableEntity {
+
+    @Inject
+    private Service service;
+
+    @Inject
+    private InitializableInnerEntity entity;
+
+    public Service getService() {
+        return service;
+    }
+
+    public InitializableInnerEntity getEntity() {
+        return entity;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/context/InitializableInnerEntity.java
+++ b/src/test/java/com/airhacks/afterburner/injection/context/InitializableInnerEntity.java
@@ -1,0 +1,36 @@
+package com.airhacks.afterburner.injection.context;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javax.inject.Inject;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InitializableInnerEntity {
+
+    @Inject
+    private Service service;
+
+    public Service getService() {
+        return service;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/context/InjectorContextTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/context/InjectorContextTest.java
@@ -1,4 +1,4 @@
-package com.airhacks.afterburner.injection.singleton;
+package com.airhacks.afterburner.injection.context;
 
 /*
  * #%L
@@ -21,8 +21,12 @@ package com.airhacks.afterburner.injection.singleton;
  */
 
 import com.airhacks.afterburner.injection.Injector;
+import com.airhacks.afterburner.injection.PresenterWithField;
 import org.junit.After;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -30,21 +34,23 @@ import static org.junit.Assert.assertSame;
 /**
  * @author Mewes Kochheim
  */
-public class InjectorSingletonTest {
+public class InjectorContextTest {
 
     /**
-     * This will test singleton and regular injection
+     * This will test inherited injection contexts
      */
     @Test
     public void testInject() {
-        InitializableEntity entity1 = new InitializableEntity();
-        Injector.inject(entity1);
+        Service service = new Service();
 
-        InitializableEntity entity2 = new InitializableEntity();
-        Injector.inject(entity2);
+        Map<String, Object> injectionContext = new HashMap<>();
+        injectionContext.put("service", service);
 
-        assertSame(entity1.getServiceSingleton(), entity2.getServiceSingleton());
-        assertNotSame(entity1.getService(), entity2.getService());
+        InitializableEntity entity = new InitializableEntity();
+        Injector.inject(entity, injectionContext::get);
+
+        assertSame(entity.getService(), service);
+        assertSame(entity.getEntity().getService(), service);
     }
 
     @After

--- a/src/test/java/com/airhacks/afterburner/injection/context/Service.java
+++ b/src/test/java/com/airhacks/afterburner/injection/context/Service.java
@@ -1,0 +1,27 @@
+package com.airhacks.afterburner.injection.context;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * @author Mewes Kochheim
+ */
+public class Service {
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/TopgunViewGuiceTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/TopgunViewGuiceTest.java
@@ -1,0 +1,101 @@
+package com.airhacks.afterburner.injection.guice;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.airhacks.afterburner.injection.guice.topgun.GunService;
+import com.airhacks.afterburner.injection.guice.topgun.TopgunPresenter;
+import com.airhacks.afterburner.injection.guice.topgun.TopgunView;
+import javafx.scene.Parent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ResourceBundle;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author adam-bien.com
+ * @author Mewes Kochheim
+ */
+public class TopgunViewGuiceTest {
+
+    private TopgunView view;
+
+    @Before
+    public void initialize() {
+        this.view = new TopgunView();
+    }
+
+    @Test
+    public void loadResourceBundle() {
+        ResourceBundle bundle = this.view.getResourceBundle();
+        assertNotNull(bundle);
+        String value = bundle.getString("top");
+        //value is fetched from the topgun.properties file
+        assertThat(value, is("gun"));
+    }
+
+    @Test
+    public void getView() {
+        Parent parent = this.view.getView();
+        assertNotNull(parent);
+    }
+
+    @Test
+    public void getPresenter() {
+        Object object = this.view.getPresenter();
+        assertNotNull(object);
+    }
+
+    @Test
+    public void getGunService() {
+        Object object = ((TopgunPresenter) this.view.getPresenter()).getGunService();
+        assertEquals(object.getClass(), GunService.class);
+    }
+
+    @Test
+    public void accessConventionalResourceBundle() {
+        TopgunPresenter topPresenter = (TopgunPresenter) this.view.getPresenter();
+        ResourceBundle bundle = topPresenter.getResourceBundle();
+        assertNotNull(bundle);
+    }
+
+    @Test
+    public void getPresengetViewWithoutRootContainerter() {
+        Object object = this.view.getViewWithoutRootContainer();
+        assertNotNull(object);
+    }
+
+    @Test
+    public void singlePresenterPerView() {
+        TopgunPresenter first = (TopgunPresenter) this.view.getPresenter();
+        TopgunPresenter second = (TopgunPresenter) this.view.getPresenter();
+        assertSame(first, second);
+    }
+
+    @After
+    public void cleanUp() {
+        System.clearProperty("host");
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/GunService.java
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/GunService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 Adam Bien.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.airhacks.afterburner.injection.guice.topgun;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ *
+ * @author adam-bien.com
+ */
+public class GunService {
+
+    public String fireAndForget() {
+        return "Fired and forgot!";
+    }
+
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/TopgunPresenter.java
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/TopgunPresenter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013 Adam Bien.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.airhacks.afterburner.injection.guice.topgun;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javafx.fxml.Initializable;
+
+import javax.inject.Inject;
+import java.net.URL;
+import java.util.Date;
+import java.util.ResourceBundle;
+
+/**
+ * FXML Controller class
+ *
+ * @author adam-bien.com
+ */
+public class TopgunPresenter implements Initializable {
+
+    @Inject
+    GunService gs;
+
+    ResourceBundle rb;
+
+    /**
+     * Initializes the controller class.
+     */
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+        this.rb = rb;
+    }
+
+    public String getMessageFromGun() {
+        return gs.fireAndForget();
+    }
+
+    public ResourceBundle getResourceBundle() {
+        return rb;
+    }
+
+    public GunService getGunService() {
+        return gs;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/TopgunView.java
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/TopgunView.java
@@ -1,0 +1,41 @@
+package com.airhacks.afterburner.injection.guice.topgun;
+
+import com.airhacks.afterburner.views.FXMLView;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import javafx.util.Callback;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ *
+ * @author Mewes Kochheim
+ */
+public class TopgunView extends FXMLView {
+
+    @Override
+    public Callback<Class<?>, Object> getControllerFactory() {
+        return (Class<?> clazz) -> {
+            Injector injector = Guice.createInjector();
+            return injector.getInstance(clazz);
+        };
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.css
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.css
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*
+ * Empty Stylesheet file.
+ */
+
+.mainFxmlClass {
+
+}

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.fxml
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.Pane?>
+<AnchorPane id="AnchorPane"
+            prefHeight="400.0"
+            prefWidth="600.0"
+            styleClass="mainFxmlClass"
+            xmlns="http://javafx.com/javafx/8"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="com.airhacks.afterburner.injection.guice.topgun.TopgunPresenter">
+    <Pane prefHeight="200.0" prefWidth="200.0" />
+</AnchorPane>

--- a/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.properties
+++ b/src/test/java/com/airhacks/afterburner/injection/guice/topgun/topgun.properties
@@ -1,0 +1,20 @@
+###
+# #%L
+# afterburner.fx
+# %%
+# Copyright (C) 2013 - 2014 Adam Bien
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+top=gun

--- a/src/test/java/com/airhacks/afterburner/injection/named/InitializableEntity.java
+++ b/src/test/java/com/airhacks/afterburner/injection/named/InitializableEntity.java
@@ -1,0 +1,72 @@
+package com.airhacks.afterburner.injection.named;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InitializableEntity {
+
+    /**
+     * Injected by field name
+     */
+    @Inject
+    private Service service;
+
+    /**
+     * Injected by name
+     */
+    @Inject
+    @Named("a")
+    private Service serviceA;
+
+    /**
+     * Injected by name
+     */
+    @Inject
+    @Named("b")
+    private Service serviceB;
+
+    /**
+     * Injected with new instance
+     */
+    @Inject
+    private Service serviceNew;
+
+    public Service getService() {
+        return service;
+    }
+
+    public Service getServiceA() {
+        return serviceA;
+    }
+
+    public Service getServiceB() {
+        return serviceB;
+    }
+
+    public Service getServiceNew() {
+        return serviceNew;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/named/InjectorNamedTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/named/InjectorNamedTest.java
@@ -1,0 +1,69 @@
+package com.airhacks.afterburner.injection.named;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.airhacks.afterburner.injection.Injector;
+import com.airhacks.afterburner.injection.PresenterWithField;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InjectorNamedTest {
+
+    /**
+     * This will test injection by field name and name
+     */
+    @Test
+    public void testInject() {
+        Service service = new Service();
+        Service serviceA = new Service();
+        Service serviceB = new Service();
+
+        Map<String, Object> injectionContext = new HashMap<>();
+        injectionContext.put("service", service);
+        injectionContext.put("a", serviceA);
+        injectionContext.put("b", serviceB);
+
+        InitializableEntity entity = new InitializableEntity();
+        Injector.inject(entity, injectionContext::get);
+
+        assertSame(entity.getService(), service);
+        assertSame(entity.getServiceA(), serviceA);
+        assertSame(entity.getServiceB(), serviceB);
+
+        assertNotSame(entity.getServiceNew(), service);
+        assertNotSame(entity.getServiceNew(), serviceA);
+        assertNotSame(entity.getServiceNew(), serviceB);
+    }
+
+    @After
+    public void reset() {
+        Injector.forgetAll();
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/named/Service.java
+++ b/src/test/java/com/airhacks/afterburner/injection/named/Service.java
@@ -1,0 +1,27 @@
+package com.airhacks.afterburner.injection.named;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * @author Mewes Kochheim
+ */
+public class Service {
+}

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/InitializableEntity.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/InitializableEntity.java
@@ -1,5 +1,25 @@
 package com.airhacks.afterburner.injection.singleton;
 
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.inject.Inject;
 
 /**

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/InitializableEntity.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/InitializableEntity.java
@@ -1,0 +1,23 @@
+package com.airhacks.afterburner.injection.singleton;
+
+import javax.inject.Inject;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InitializableEntity {
+
+    @Inject
+    private Service service;
+
+    @Inject
+    private ServiceSingleton serviceSingleton;
+
+    public Service getService() {
+        return service;
+    }
+
+    public ServiceSingleton getServiceSingleton() {
+        return serviceSingleton;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/InjectorSingletonTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/InjectorSingletonTest.java
@@ -1,0 +1,51 @@
+package com.airhacks.afterburner.injection.singleton;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.airhacks.afterburner.injection.Injector;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class InjectorSingletonTest {
+
+    @Test
+    public void testInjectMembers() {
+        InitializableEntity entity1 = new InitializableEntity();
+        Injector.injectMembers(InitializableEntity.class, entity1);
+
+        InitializableEntity entity2 = new InitializableEntity();
+        Injector.injectMembers(InitializableEntity.class, entity2);
+
+        assertSame(entity1.getServiceSingleton(), entity2.getServiceSingleton());
+        assertNotSame(entity1.getService(), entity2.getService());
+    }
+
+    @After
+    public void reset() {
+        Injector.forgetAll();
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/InjectorSingletonTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/InjectorSingletonTest.java
@@ -35,10 +35,10 @@ public class InjectorSingletonTest {
     @Test
     public void testInjectMembers() {
         InitializableEntity entity1 = new InitializableEntity();
-        Injector.injectMembers(InitializableEntity.class, entity1);
+        Injector.inject(entity1);
 
         InitializableEntity entity2 = new InitializableEntity();
-        Injector.injectMembers(InitializableEntity.class, entity2);
+        Injector.inject(entity2);
 
         assertSame(entity1.getServiceSingleton(), entity2.getServiceSingleton());
         assertNotSame(entity1.getService(), entity2.getService());

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/Service.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/Service.java
@@ -1,5 +1,25 @@
 package com.airhacks.afterburner.injection.singleton;
 
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 /**
  * @author Mewes Kochheim
  */

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/Service.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/Service.java
@@ -1,0 +1,7 @@
+package com.airhacks.afterburner.injection.singleton;
+
+/**
+ * @author Mewes Kochheim
+ */
+public class Service {
+}

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/ServiceSingleton.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/ServiceSingleton.java
@@ -1,5 +1,25 @@
 package com.airhacks.afterburner.injection.singleton;
 
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2015 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.inject.Singleton;
 
 /**

--- a/src/test/java/com/airhacks/afterburner/injection/singleton/ServiceSingleton.java
+++ b/src/test/java/com/airhacks/afterburner/injection/singleton/ServiceSingleton.java
@@ -1,0 +1,10 @@
+package com.airhacks.afterburner.injection.singleton;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Mewes Kochheim
+ */
+@Singleton
+public class ServiceSingleton {
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/TopgunViewWeldTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/TopgunViewWeldTest.java
@@ -1,0 +1,101 @@
+package com.airhacks.afterburner.injection.weld;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.airhacks.afterburner.injection.weld.topgun.GunService;
+import com.airhacks.afterburner.injection.weld.topgun.TopgunPresenter;
+import com.airhacks.afterburner.injection.weld.topgun.TopgunView;
+import javafx.scene.Parent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ResourceBundle;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author adam-bien.com
+ * @author Mewes Kochheim
+ */
+public class TopgunViewWeldTest {
+
+    private TopgunView view;
+
+    @Before
+    public void initialize() {
+        this.view = new TopgunView();
+    }
+
+    @Test
+    public void loadResourceBundle() {
+        ResourceBundle bundle = this.view.getResourceBundle();
+        assertNotNull(bundle);
+        String value = bundle.getString("top");
+        //value is fetched from the topgun.properties file
+        assertThat(value, is("gun"));
+    }
+
+    @Test
+    public void getView() {
+        Parent parent = this.view.getView();
+        assertNotNull(parent);
+    }
+
+    @Test
+    public void getPresenter() {
+        Object object = this.view.getPresenter();
+        assertNotNull(object);
+    }
+
+    @Test
+    public void getGunService() {
+        Object object = ((com.airhacks.afterburner.injection.weld.topgun.TopgunPresenter) this.view.getPresenter()).getGunService();
+        assertTrue(GunService.class.isInstance(object));
+    }
+
+    @Test
+    public void accessConventionalResourceBundle() {
+        TopgunPresenter topPresenter = (TopgunPresenter) this.view.getPresenter();
+        ResourceBundle bundle = topPresenter.getResourceBundle();
+        assertNotNull(bundle);
+    }
+
+    @Test
+    public void getPresengetViewWithoutRootContainerter() {
+        Object object = this.view.getViewWithoutRootContainer();
+        assertNotNull(object);
+    }
+
+    @Test
+    public void singlePresenterPerView() {
+        TopgunPresenter first = (TopgunPresenter) this.view.getPresenter();
+        TopgunPresenter second = (TopgunPresenter) this.view.getPresenter();
+        assertSame(first, second);
+    }
+
+    @After
+    public void cleanUp() {
+        System.clearProperty("host");
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/GunService.java
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/GunService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 Adam Bien.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.airhacks.afterburner.injection.weld.topgun;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2014 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author adam-bien.com
+ */
+@ApplicationScoped
+public class GunService {
+
+    public String fireAndForget() {
+        return "Fired and forgot!";
+    }
+
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/TopgunPresenter.java
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/TopgunPresenter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013 Adam Bien.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.airhacks.afterburner.injection.weld.topgun;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javafx.fxml.Initializable;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.net.URL;
+import java.util.ResourceBundle;
+
+/**
+ * FXML Controller class
+ *
+ * @author adam-bien.com
+ */
+@ApplicationScoped
+public class TopgunPresenter implements Initializable {
+
+    @Inject
+    GunService gs;
+
+    ResourceBundle rb;
+
+    /**
+     * Initializes the controller class.
+     */
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+        this.rb = rb;
+    }
+
+    public String getMessageFromGun() {
+        return gs.fireAndForget();
+    }
+
+    public ResourceBundle getResourceBundle() {
+        return rb;
+    }
+
+    public GunService getGunService() {
+        return gs;
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/TopgunView.java
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/TopgunView.java
@@ -1,0 +1,41 @@
+package com.airhacks.afterburner.injection.weld.topgun;
+
+import com.airhacks.afterburner.views.FXMLView;
+import javafx.util.Callback;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ *
+ * @author Mewes Kochheim
+ */
+public class TopgunView extends FXMLView {
+
+    @Override
+    public Callback<Class<?>, Object> getControllerFactory() {
+        return (Class<?> clazz) -> {
+            WeldContainer weldContainer = new Weld().initialize();
+            return weldContainer.instance().select(clazz).get();
+        };
+    }
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.css
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.css
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*
+ * Empty Stylesheet file.
+ */
+
+.mainFxmlClass {
+
+}

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.fxml
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.Pane?>
+<AnchorPane id="AnchorPane"
+            prefHeight="400.0"
+            prefWidth="600.0"
+            styleClass="mainFxmlClass"
+            xmlns="http://javafx.com/javafx/8"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="com.airhacks.afterburner.injection.weld.topgun.TopgunPresenter">
+    <Pane prefHeight="200.0" prefWidth="200.0" />
+</AnchorPane>

--- a/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.properties
+++ b/src/test/java/com/airhacks/afterburner/injection/weld/topgun/topgun.properties
@@ -1,0 +1,20 @@
+###
+# #%L
+# afterburner.fx
+# %%
+# Copyright (C) 2013 - 2014 Adam Bien
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+top=gun

--- a/src/test/java/com/airhacks/afterburner/lifecycle/ConcreteModel.java
+++ b/src/test/java/com/airhacks/afterburner/lifecycle/ConcreteModel.java
@@ -35,12 +35,14 @@ package com.airhacks.afterburner.lifecycle;
  * #L%
  */
 
+import javax.inject.Singleton;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
  * @author adam-bien.com
  */
+@Singleton
 public class ConcreteModel extends AbstractModel {
 
     private final AtomicInteger initializationCounter = new AtomicInteger(0);

--- a/src/test/java/com/airhacks/afterburner/lifecycle/lifecycle.fxml
+++ b/src/test/java/com/airhacks/afterburner/lifecycle/lifecycle.fxml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import java.net.*?>
-<?import java.util.*?>
-<?import javafx.scene.*?>
-<?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
 <AnchorPane id="AnchorPane" prefHeight="400.0" prefWidth="600.0" styleClass="mainFxmlClass" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.airhacks.afterburner.lifecycle.LifecyclePresenter">

--- a/src/test/java/com/airhacks/afterburner/topgun/topgun.fxml
+++ b/src/test/java/com/airhacks/afterburner/topgun/topgun.fxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
 <AnchorPane id="AnchorPane" prefHeight="400.0" prefWidth="600.0" styleClass="mainFxmlClass" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8" fx:controller="com.airhacks.afterburner.topgun.TopgunPresenter">
-<children><Pane prefHeight="200.0" prefWidth="200.0" />
-</children></AnchorPane>
+    <Pane prefHeight="200.0" prefWidth="200.0" />
+</AnchorPane>

--- a/src/test/java/com/airhacks/afterburner/topgun/topgun.properties
+++ b/src/test/java/com/airhacks/afterburner/topgun/topgun.properties
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/airhacks/afterburner/views/TopgunViewTest.java
+++ b/src/test/java/com/airhacks/afterburner/views/TopgunViewTest.java
@@ -143,15 +143,11 @@ public class TopgunViewTest {
     }
 
     Function<String, Object> getInjectionContext(String fieldName, Object value) {
-        return new Function<String, Object>() {
-
-            @Override
-            public Object apply(String key) {
-                if (fieldName.equalsIgnoreCase(key)) {
-                    return value;
-                }
-                return null;
+        return key -> {
+            if (fieldName.equalsIgnoreCase(key)) {
+                return value;
             }
+            return null;
         };
     }
 

--- a/src/test/resources/META-INF/beans.xml
+++ b/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<!--
+  #%L
+  afterburner.fx
+  %%
+  Copyright (C) 2013 - 2015 Adam Bien
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
I have certain services that should not be a singleton but have @Injected fields.
So instead of instantiating the service and injecting the members manually, ...

```java
private SearchService searchService = Injector.instantiateModelOrService(SearchService.class);
```

a proper @Singleton support would be the cleanest solution.

Sadly the default @Inject implementation of ab.fx treats every service as a singleton. So to follow the Java way I had to change the default behavior of ab.fx. A @NotSingleton interface would have been backward compatible but doesn't follow JSR 330.

So to get old behavior I can just add @Singleton to a class. Without it every injected instance is new and only cached if it has a @PreDestroy annotation to be called later.

I also implemented support for @Named annotations. It is used in combination with the injection context.

To be able to use the injection context properly I had to make it apply to every injection method. Which means that now it is usable for models and services too and it's also inherited to inner injections!

All these new features made some significant API changes necessary (only regarding model and service injection though) but the result is a much cleaner and more easy to use Injector API. Of course I've added some unit tests to cover all these changes.

I know that this PR is not BC but I believe that these changes will benefit other ab.fx users. It would be awesome if you could send this PR upstream! Meanwhile I'll continue to use and improve my fork.
