### PR TITLE
Enable access to properties with dots in name over the annotation Named.

### DIFF
--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -22,6 +22,7 @@ package com.airhacks.afterburner.views;
 import com.airhacks.afterburner.injection.Injector;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import static java.util.ResourceBundle.getBundle;
@@ -57,23 +58,51 @@ public abstract class FXMLView {
         thread.setDaemon(true);
         return thread;
     });
+    
+    private Locale localeToLowerCase = Locale.ENGLISH;
 
     /**
      * Constructs the view lazily (fxml is not loaded) with empty injection
-     * context.
+     * context and Locale.ENGLISH for the name converting.
      */
     public FXMLView() {
-        this(f -> null);
+        this(Locale.ENGLISH);
+    }
+    
+    /**
+     * Constructs the view lazily (fxml is not loaded) with empty injection
+     * context.
+     * 
+     * @param localeToLowerCase The locale for the name converting.
+     */
+    public FXMLView(Locale localeToLowerCase) {
+        this(f -> null, localeToLowerCase);
     }
 
     /**
+     * Constructs the view lazily (fxml is not loaded) and Locale.ENGLISH for 
+     * the name converting.
      *
      * @param injectionContext the function is used as a injection source.
      * Values matching for the keys are going to be used for injection into the
      * corresponding presenter.
      */
     public FXMLView(Function<String, Object> injectionContext) {
+        this(injectionContext, Locale.ENGLISH);
+    }
+    
+    /**
+     * Constructs the view lazily (fxml is not loaded).
+     * 
+     * @param injectionContext the function is used as a injection source.
+     * Values matching for the keys are going to be used for injection into the
+     * corresponding presenter.
+     * @param localeToLowerCase The locale for the name converting.
+     */
+    public FXMLView(Function<String, Object> injectionContext, Locale localeToLowerCase) {
         this.injectionContext = injectionContext;
+        this.localeToLowerCase = localeToLowerCase;
+        
         this.init(getFXMLName());
     }
 
@@ -221,26 +250,46 @@ public abstract class FXMLView {
     }
 
     /**
+     * Returns the conventional name.
      *
      * @param lowercase indicates whether the simple class name should be
-     * converted to lowercase of left unchanged
-     * @param ending the suffix to append
-     * @return the conventional name with stripped ending
+     * converted to lowercase or left unchanged. Use the parameter 
+     * {@code localeToLowerCase} for the to lowercase converting.
+     * @param ending the suffix to append.
+     * 
+     * @return the conventional name with stripped ending.
      */
     protected String getConventionalName(boolean lowercase, String ending) {
-        return getConventionalName(lowercase) + ending;
+        return getConventionalName(lowercase, localeToLowerCase) + ending;
     }
 
     /**
+     * Returns the conventional name.
      *
      * @param lowercase indicates whether the simple class name should be
-     * @return the name of the view without the "View" prefix.
+     * converted to lowercase or left unchanged. Use the parameter 
+     * {@code localeToLowerCase} for the to lowercase converting.
+     * 
+     * @return the name of the view without the "View" suffix.
      */
     protected String getConventionalName(boolean lowercase) {
+        return getConventionalName(lowercase, localeToLowerCase);
+    }
+    
+    /**
+     * 
+     * @param lowercase indicates whether the simple class name should be
+     * converted to lowercase or left unchanged.
+     * @param locale Converts all of the characters in this {@code String} to lower
+     * case using the rules of the given {@code Locale}.
+     * 
+     * @return the name of the view without the "View" suffix.
+     */
+    String getConventionalName(boolean lowercase, Locale locale) {
         final String clazzWithEnding = this.getClass().getSimpleName();
         String clazz = stripEnding(clazzWithEnding);
         if (lowercase) {
-            clazz = clazz.toLowerCase();
+            clazz = clazz.toLowerCase(locale);
         }
         return clazz;
     }

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -59,14 +59,14 @@ public abstract class FXMLView {
         return thread;
     });
     
-    private Locale localeToLowerCase = Locale.ENGLISH;
+    private Locale localeToLowerCase = Locale.getDefault();
 
     /**
      * Constructs the view lazily (fxml is not loaded) with empty injection
-     * context and Locale.ENGLISH for the name converting.
+     * context and {@link java.util.Locale#getDefault()} for the name converting.
      */
     public FXMLView() {
-        this(Locale.ENGLISH);
+        this(Locale.getDefault());
     }
     
     /**
@@ -80,15 +80,15 @@ public abstract class FXMLView {
     }
 
     /**
-     * Constructs the view lazily (fxml is not loaded) and Locale.ENGLISH for 
-     * the name converting.
+     * Constructs the view lazily (fxml is not loaded) and {@link java.util.Locale#getDefault()} 
+     * for the name converting.
      *
      * @param injectionContext the function is used as a injection source.
      * Values matching for the keys are going to be used for injection into the
      * corresponding presenter.
      */
     public FXMLView(Function<String, Object> injectionContext) {
-        this(injectionContext, Locale.ENGLISH);
+        this(injectionContext, Locale.getDefault());
     }
     
     /**

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -89,10 +89,15 @@ public class InjectorTest {
     @Test
     public void injectionContextWithMathingKey() {
         String expected = "hello duke";
+        String nameWithDots = "This is a name with dots";
         Map<String, Object> injectionContext = new HashMap<>();
         injectionContext.put("name", expected);
+        injectionContext.put(PresenterWithField.NAME_WITH_DOTS, nameWithDots);
+        
         PresenterWithField withField = Injector.instantiatePresenter(PresenterWithField.class, injectionContext::get);
         assertThat(withField.getName(), is(expected));
+        assertThat(withField.getNameWithDots(), is(nameWithDots));
+        
         Injector.forgetAll();
     }
 
@@ -136,10 +141,14 @@ public class InjectorTest {
     @Test
     public void systemPropertiesInjectionOfExistingProperty() {
         final String expected = "42";
+        final String systemPropertyWithDots = "This is a system property with dots";
         System.setProperty("shouldExist", expected);
+        System.setProperty(SystemProperties.SYSTEM_PROPERTY_WITH_DOTS, systemPropertyWithDots);
+        
         SystemProperties systemProperties = Injector.injectAndInitialize(new SystemProperties());
         String actual = systemProperties.getShouldExist();
         assertThat(actual, is(expected));
+        assertThat(systemProperties.getSystemPropertyWithDots(), is(systemPropertyWithDots));
     }
 
     @Test
@@ -185,7 +194,7 @@ public class InjectorTest {
     
 	@Test
     public void logging() {
-		@SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked")
         Consumer<String> logger = mock(Consumer.class);
         Injector.setLogger(logger);
         Injector.injectAndInitialize(new DateProperties());

--- a/src/test/java/com/airhacks/afterburner/injection/PresenterWithField.java
+++ b/src/test/java/com/airhacks/afterburner/injection/PresenterWithField.java
@@ -36,18 +36,29 @@ package com.airhacks.afterburner.injection;
  */
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  *
  * @author airhacks.com
  */
 public class PresenterWithField {
+    
+    public final static String NAME_WITH_DOTS = "name.with.dots";
 
     @Inject
     private String name;
+    
+    @Inject
+    @Named(NAME_WITH_DOTS)
+    private String nameWithDots;
 
     public String getName() {
         return name;
+    }
+    
+    public String getNameWithDots() {
+        return nameWithDots;
     }
 
 }

--- a/src/test/java/com/airhacks/afterburner/injection/SystemProperties.java
+++ b/src/test/java/com/airhacks/afterburner/injection/SystemProperties.java
@@ -36,6 +36,7 @@ package com.airhacks.afterburner.injection;
  */
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  *
@@ -43,11 +44,17 @@ import javax.inject.Inject;
  */
 public class SystemProperties {
 
+    public final static String SYSTEM_PROPERTY_WITH_DOTS = "system.property.with.dots";
+    
     @Inject
     private String shouldExist;
 
     @Inject
     private String doesNotExists;
+    
+    @Inject
+    @Named(SYSTEM_PROPERTY_WITH_DOTS)
+    private String systemPropertyWithDots;
 
     public String getShouldExist() {
         return shouldExist;
@@ -55,6 +62,10 @@ public class SystemProperties {
 
     public String getDoesNotExists() {
         return doesNotExists;
+    }
+    
+    public String getSystemPropertyWithDots() {
+        return systemPropertyWithDots;
     }
 
 }


### PR DESCRIPTION
Hi Adam,
a common practice is to use properties keys with dots which is unfortunaly momentary not possible in afterburner.fx.

I have extends the functionality from `Injector.instantiatePresenter(...)` and `Injector.injectMembers(...)` (see also the tests in `InjectorTest`) so that is now possible to read and access the properties which have keys with dots over the annotation `@Named("key.with.dots")`. In both methods first the @Inject annotation is read like before and if the field have the additional annotation @Named, then the value() from this annotation will be used.

Greetings
Peter