### PR TITLE
allow local injection of classes without default constructor

### DIFF
--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -55,9 +55,9 @@ public class Injector {
     private static final Configurator configurator = new Configurator();
 
     
-	public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
-		@SuppressWarnings("unchecked")
-		T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz), injectionContext);
+    public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
+        @SuppressWarnings("unchecked")
+        T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz), injectionContext);
         return presenter;
     }
 
@@ -93,19 +93,19 @@ public class Injector {
      * @return presenter with injected fields
      */
     public static <T> T registerExistingAndInject(T instance) {
-		return registerExistingAndInject(instance, null);
+        return registerExistingAndInject(instance, null);
     }
 
-	public static <T> T registerExistingAndInject(T instance, Function<String, Object> additionalInjectionContext) {
-		T product = injectAndInitialize(instance, additionalInjectionContext);
-		presenters.add(product);
-		return product;
-	}
+    public static <T> T registerExistingAndInject(T instance, Function<String, Object> additionalInjectionContext) {
+        T product = injectAndInitialize(instance, additionalInjectionContext);
+        presenters.add(product);
+        return product;
+    }
 
     
-	@SuppressWarnings("unchecked")
-	public static <T> T instantiateModelOrService(Class<T> clazz) {
-		T product = (T) modelsAndServices.get(clazz);
+    @SuppressWarnings("unchecked")
+    public static <T> T instantiateModelOrService(Class<T> clazz) {
+        T product = (T) modelsAndServices.get(clazz);
         if (product == null) {
             product = injectAndInitialize((T)instanceSupplier.apply(clazz));
             modelsAndServices.putIfAbsent(clazz, product);
@@ -117,29 +117,29 @@ public class Injector {
         modelsAndServices.put(clazz, instance);
     }
 
-	static <T> T injectAndInitialize(T product) {
-		return injectAndInitialize(product, null);
-	}
+    static <T> T injectAndInitialize(T product) {
+        return injectAndInitialize(product, null);
+    }
 
 
-	static <T> T injectAndInitialize(T product, Function<String, Object> additionalInjectionContext) {
+    static <T> T injectAndInitialize(T product, Function<String, Object> additionalInjectionContext) {
         injectMembers(product, additionalInjectionContext);
         initialize(product);
         return product;
     }
 
-	static void injectMembers(final Object instance) {
-		injectMembers(instance, null);
-	}
+    static void injectMembers(final Object instance) {
+        injectMembers(instance, null);
+    }
 
-	static void injectMembers(final Object instance, Function<String, Object> additionalInjectionContext) {
+    static void injectMembers(final Object instance, Function<String, Object> additionalInjectionContext) {
         Class<? extends Object> clazz = instance.getClass();
         injectMembers(clazz, instance, additionalInjectionContext);
     }
 
     public static void injectMembers(Class<? extends Object> clazz, final Object instance) throws SecurityException {
-		injectMembers(clazz, instance, null);
-	}
+        injectMembers(clazz, instance, null);
+    }
 
     public static void injectMembers(Class<? extends Object> clazz, final Object instance, Function<String, Object> additionalInjectionContext) throws SecurityException {
         LOG.accept("Injecting members for class " + clazz + " and instance " + instance);
@@ -149,20 +149,20 @@ public class Injector {
                 LOG.accept("Field annotated with @Inject found: " + field);
                 Class<?> type = field.getType();
                 String key = field.getName();
-				Object value = null;
-				if (additionalInjectionContext != null) {
-					value = additionalInjectionContext.apply(key);
-				}
-				if (additionalInjectionContext == null || value == null) {
-					value = configurator.getProperty(clazz, key);
-					LOG.accept("Value returned by configurator is: " + value);
-					if (value == null && isNotPrimitiveOrString(type)) {
-						LOG.accept("Field is not a JDK class");
-						value = instantiateModelOrService(type);
-					}
-				}
+                Object value = null;
+                if (additionalInjectionContext != null) {
+                    value = additionalInjectionContext.apply(key);
+                }
+                if (additionalInjectionContext == null || value == null) {
+                    value = configurator.getProperty(clazz, key);
+                    LOG.accept("Value returned by configurator is: " + value);
+                    if (value == null && isNotPrimitiveOrString(type)) {
+                        LOG.accept("Field is not a JDK class");
+                        value = instantiateModelOrService(type);
+                    }
+                }
 
-				if (value != null) {
+                if (value != null) {
                     LOG.accept("Value is a primitive, injecting...");
                     injectIntoField(field, instance, value);
                 }
@@ -175,7 +175,7 @@ public class Injector {
         }
     }
 
-	static void injectIntoField(final Field field, final Object instance, final Object target) {
+    static void injectIntoField(final Field field, final Object instance, final Object target) {
         AccessController.doPrivileged((PrivilegedAction<?>) () -> {
             boolean wasAccessible = field.isAccessible();
             try {

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -58,17 +58,6 @@ public class Injector {
 	public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
 		@SuppressWarnings("unchecked")
 		T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz), injectionContext);
-        //after the regular, conventional initialization and injection, perform postinjection
-        Field[] fields = clazz.getDeclaredFields();
-        for (final Field field : fields) {
-            if (field.isAnnotationPresent(Inject.class)) {
-                final String fieldName = field.getName();
-                final Object value = injectionContext.apply(fieldName);
-                if (value != null) {
-                    injectIntoField(field, presenter, value);
-                }
-            }
-        }
         return presenter;
     }
 

--- a/src/main/java/com/airhacks/afterburner/injection/Injector.java
+++ b/src/main/java/com/airhacks/afterburner/injection/Injector.java
@@ -57,7 +57,7 @@ public class Injector {
     
 	public static <T> T instantiatePresenter(Class<T> clazz, Function<String, Object> injectionContext) {
 		@SuppressWarnings("unchecked")
-		T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz));
+		T presenter = registerExistingAndInject( (T)instanceSupplier.apply(clazz), injectionContext);
         //after the regular, conventional initialization and injection, perform postinjection
         Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {
@@ -104,10 +104,14 @@ public class Injector {
      * @return presenter with injected fields
      */
     public static <T> T registerExistingAndInject(T instance) {
-        T product = injectAndInitialize(instance);
-        presenters.add(product);
-        return product;
+		return registerExistingAndInject(instance, null);
     }
+
+	public static <T> T registerExistingAndInject(T instance, Function<String, Object> additionalInjectionContext) {
+		T product = injectAndInitialize(instance, additionalInjectionContext);
+		presenters.add(product);
+		return product;
+	}
 
     
 	@SuppressWarnings("unchecked")
@@ -124,18 +128,31 @@ public class Injector {
         modelsAndServices.put(clazz, instance);
     }
 
-    static <T> T injectAndInitialize(T product) {
-        injectMembers(product);
+	static <T> T injectAndInitialize(T product) {
+		return injectAndInitialize(product, null);
+	}
+
+
+	static <T> T injectAndInitialize(T product, Function<String, Object> additionalInjectionContext) {
+        injectMembers(product, additionalInjectionContext);
         initialize(product);
         return product;
     }
 
-    static void injectMembers(final Object instance) {
+	static void injectMembers(final Object instance) {
+		injectMembers(instance, null);
+	}
+
+	static void injectMembers(final Object instance, Function<String, Object> additionalInjectionContext) {
         Class<? extends Object> clazz = instance.getClass();
-        injectMembers(clazz, instance);
+        injectMembers(clazz, instance, additionalInjectionContext);
     }
 
     public static void injectMembers(Class<? extends Object> clazz, final Object instance) throws SecurityException {
+		injectMembers(clazz, instance, null);
+	}
+
+    public static void injectMembers(Class<? extends Object> clazz, final Object instance, Function<String, Object> additionalInjectionContext) throws SecurityException {
         LOG.accept("Injecting members for class " + clazz + " and instance " + instance);
         Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {
@@ -143,13 +160,20 @@ public class Injector {
                 LOG.accept("Field annotated with @Inject found: " + field);
                 Class<?> type = field.getType();
                 String key = field.getName();
-                Object value = configurator.getProperty(clazz, key);
-                LOG.accept("Value returned by configurator is: " + value);
-                if (value == null && isNotPrimitiveOrString(type)) {
-                    LOG.accept("Field is not a JDK class");
-                    value = instantiateModelOrService(type);
-                }
-                if (value != null) {
+				Object value = null;
+				if (additionalInjectionContext != null) {
+					value = additionalInjectionContext.apply(key);
+				}
+				if (additionalInjectionContext == null || value == null) {
+					value = configurator.getProperty(clazz, key);
+					LOG.accept("Value returned by configurator is: " + value);
+					if (value == null && isNotPrimitiveOrString(type)) {
+						LOG.accept("Field is not a JDK class");
+						value = instantiateModelOrService(type);
+					}
+				}
+
+				if (value != null) {
                     LOG.accept("Value is a primitive, injecting...");
                     injectIntoField(field, instance, value);
                 }

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.verify;
 public class InjectorTest {
 
     
-	@Test
+    @Test
     public void injection() {
         View view = Injector.instantiatePresenter(View.class);
         Boundary boundary = view.getBoundary();
@@ -96,15 +96,15 @@ public class InjectorTest {
         Injector.forgetAll();
     }
 
-	@Test
-	public void injectionContextWithNoBeanOrPrimitive() {
-		NotABean expected = new NotABean(25);
-		Map<String, Object> injectionContext = new HashMap<>();
-		injectionContext.put("name", expected);
-		PresenterWithNotABeanField withField = Injector.instantiatePresenter(PresenterWithNotABeanField.class, injectionContext::get);
-		assertThat(withField.getName(), is(expected));
-		Injector.forgetAll();
-	}
+    @Test
+    public void injectionContextWithNoBeanOrPrimitive() {
+        NotABean expected = new NotABean(25);
+        Map<String, Object> injectionContext = new HashMap<>();
+        injectionContext.put("name", expected);
+        PresenterWithNotABeanField withField = Injector.instantiatePresenter(PresenterWithNotABeanField.class, injectionContext::get);
+        assertThat(withField.getName(), is(expected));
+        Injector.forgetAll();
+    }
 
     @Test
     public void forgetAllModels() {
@@ -193,9 +193,9 @@ public class InjectorTest {
         assertNotNull(actual);
     }
     
-	@Test
+    @Test
     public void logging() {
-		@SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked")
         Consumer<String> logger = mock(Consumer.class);
         Injector.setLogger(logger);
         Injector.injectAndInitialize(new DateProperties());

--- a/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/InjectorTest.java
@@ -96,6 +96,16 @@ public class InjectorTest {
         Injector.forgetAll();
     }
 
+	@Test
+	public void injectionContextWithNoBeanOrPrimitive() {
+		NotABean expected = new NotABean(25);
+		Map<String, Object> injectionContext = new HashMap<>();
+		injectionContext.put("name", expected);
+		PresenterWithNotABeanField withField = Injector.instantiatePresenter(PresenterWithNotABeanField.class, injectionContext::get);
+		assertThat(withField.getName(), is(expected));
+		Injector.forgetAll();
+	}
+
     @Test
     public void forgetAllModels() {
         Model first = Injector.instantiateModelOrService(Model.class);

--- a/src/test/java/com/airhacks/afterburner/injection/NotABean.java
+++ b/src/test/java/com/airhacks/afterburner/injection/NotABean.java
@@ -21,9 +21,9 @@ package com.airhacks.afterburner.injection;
  */
 
 public class NotABean {
-	private int someProperty;
+    private int someProperty;
 
-	public NotABean(int someProperty) {
-		this.someProperty = someProperty;
-	}
+    public NotABean(int someProperty) {
+        this.someProperty = someProperty;
+    }
 }

--- a/src/test/java/com/airhacks/afterburner/injection/NotABean.java
+++ b/src/test/java/com/airhacks/afterburner/injection/NotABean.java
@@ -1,0 +1,29 @@
+package com.airhacks.afterburner.injection;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2016 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class NotABean {
+	private int someProperty;
+
+	public NotABean(int someProperty) {
+		this.someProperty = someProperty;
+	}
+}

--- a/src/test/java/com/airhacks/afterburner/injection/PresenterWithNotABeanField.java
+++ b/src/test/java/com/airhacks/afterburner/injection/PresenterWithNotABeanField.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Adam Bien.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.airhacks.afterburner.injection;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2016 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import javax.inject.Inject;
+
+public class PresenterWithNotABeanField {
+	@Inject
+	private NotABean name;
+
+	public NotABean getName() {
+		return name;
+	}
+}

--- a/src/test/java/com/airhacks/afterburner/injection/PresenterWithNotABeanField.java
+++ b/src/test/java/com/airhacks/afterburner/injection/PresenterWithNotABeanField.java
@@ -38,10 +38,10 @@ package com.airhacks.afterburner.injection;
 import javax.inject.Inject;
 
 public class PresenterWithNotABeanField {
-	@Inject
-	private NotABean name;
+    @Inject
+    private NotABean name;
 
-	public NotABean getName() {
-		return name;
-	}
+    public NotABean getName() {
+        return name;
+    }
 }


### PR DESCRIPTION
The test shows the problem.
When using @inject with a local injectionContext, the properties are injected twice (once from the global injectionContext/configurator and once from the local injectionContext).
Of course most of the time, the local elements won't be contained in the global context and get thus instantiated. With beans this works by accident, because new instances can be created with the default constructor, but when no default constructor is available, the defaultInstanceSupplier will call `c.newInstance()` on the default constructor that does not exist.

This fix moves the lookup of the property to inject in local injectionContext so that it is not injected twice and doesn't get injected from the wrong context, thus fixing the problem.