### PR TITLE
Make exceptions during FXMLView.getView() loggable

### DIFF
--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -57,6 +57,7 @@ public abstract class FXMLView {
         thread.setDaemon(true);
         return thread;
     });
+    private static Consumer<Throwable> LOG;
 
     /**
      * Constructs the view lazily (fxml is not loaded) with empty injection
@@ -124,7 +125,11 @@ public abstract class FXMLView {
     public void getView(Consumer<Parent> consumer) {
         Supplier<Parent> supplier = this::getView;
         Executor fxExecutor = Platform::runLater;
-        CompletableFuture.supplyAsync(supplier, fxExecutor).thenAccept(consumer);
+        CompletableFuture.supplyAsync(supplier, fxExecutor).thenAccept(consumer)
+            .exceptionally(throwable -> {
+              LOG.accept(throwable);
+              return null;
+            });
     }
 
     /**
@@ -274,4 +279,7 @@ public abstract class FXMLView {
         return this.bundle;
     }
 
+    public static void setDefaultExceptionLogger(Consumer<Throwable> throwableConsumer){
+      LOG = throwableConsumer;
+    }
 }


### PR DESCRIPTION
In case that during getView() an exception occurs, this exception would currently be lost, 
because CompletableFuture.supplyAsync() does not handle exceptions per default.
So I added the .exceptionally() call during getView() to get an exception, if one occurs.

Best Regards
Rene Fischer