### PR TITLE
Make initializeFXMLLoader protected

### DIFF
--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -96,7 +96,7 @@ public abstract class FXMLView extends StackPane {
         return loader;
     }
 
-    void initializeFXMLLoader() {
+    protected void initializeFXMLLoader() {
         if (this.fxmlLoader == null) {
             this.fxmlLoader = this.loadSynchronously(resource, bundle, bundleName);
             this.presenterProperty.set(this.fxmlLoader.getController());


### PR DESCRIPTION
I propose to make initializeFXMLLoader protected so that the view can change the FXML loader before the .fxml file is loaded (for example, to change the resource bundle).