### PR TITLE
no longer apply retrolambda to classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,19 +150,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>net.orfjackal.retrolambda</groupId>
-                <artifactId>retrolambda-maven-plugin</artifactId>
-                <version>1.8.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>process-main</goal>
-                            <goal>process-test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
Retrolambda is a tool that converts the bytecode of classes that are compiled against 1.8 to bytecode that is compatible for running on a 1.7 or 1.6 environment. We recently made changes in our gradle build plugin (https://bitbucket.org/javafxports/javafxmobile-plugin) that automatically applies the retrolambda tool on all project classes and all the classes inside dependent libraries (like afterburner.mfx).

This means, that libraries themselves no longer should apply retrolambda themselves. In fact, doing so, makes it harder, because in the end it will have retrolambda applied twice: once by the library's own build process and a second time by the jfxmobile build process. This will in most cases result in java errors at runtime (i.e. java.lang.IncompatibleClassChangeError).