### PR TITLE
Add initial editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This adds an initial [editorconfig](http://editorconfig.org/) to ensure that all contributors use the same file style.