### PR TITLE
Provide a way to influence how the PresenterFactory is found by the ServiceLoader

### DIFF
--- a/src/main/java/com/airhacks/afterburner/injection/PresenterFactory.java
+++ b/src/main/java/com/airhacks/afterburner/injection/PresenterFactory.java
@@ -72,8 +72,8 @@ public interface PresenterFactory {
      * @return all discovered implementations of PresenterFactory using the
      * {@link java.util.ServiceLoader} mechanism
      */
-    static Iterable<PresenterFactory> discover() {
-        return ServiceLoader.load(PresenterFactory.class);
+    static Iterable<PresenterFactory> discover(ClassLoader classLoader) {
+        return ServiceLoader.load(PresenterFactory.class, classLoader);
     }
 
 }

--- a/src/main/java/com/airhacks/afterburner/views/FXMLView.java
+++ b/src/main/java/com/airhacks/afterburner/views/FXMLView.java
@@ -104,7 +104,7 @@ public abstract class FXMLView extends StackPane {
     }
 
     PresenterFactory discover() {
-        Iterable<PresenterFactory> discoveredFactories = PresenterFactory.discover();
+        Iterable<PresenterFactory> discoveredFactories = PresenterFactory.discover(getClassLoader());
         List<PresenterFactory> factories = StreamSupport.stream(discoveredFactories.spliterator(), false).
                 collect(Collectors.toList());
         if (factories.isEmpty()) {
@@ -324,4 +324,7 @@ public abstract class FXMLView extends StackPane {
         return null;
     }
 
+    public ClassLoader getClassLoader() {
+        return Thread.currentThread().getContextClassLoader();
+    }
 }

--- a/src/test/java/com/airhacks/afterburner/injection/PresenterFactoryTest.java
+++ b/src/test/java/com/airhacks/afterburner/injection/PresenterFactoryTest.java
@@ -51,7 +51,7 @@ public class PresenterFactoryTest {
 
     @Test
     public void discoverPresenter() {
-        Iterable<PresenterFactory> presenters = PresenterFactory.discover();
+        Iterable<PresenterFactory> presenters = PresenterFactory.discover(Thread.currentThread().getContextClassLoader());
         List<PresenterFactory> all = StreamSupport.stream(presenters.spliterator(), false).collect(Collectors.toList());
         assertThat(all.size(), is(1));
         PresenterFactory discovered = all.get(0);

--- a/src/test/java/com/airhacks/afterburner/topgun/topgun.properties
+++ b/src/test/java/com/airhacks/afterburner/topgun/topgun.properties
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Provide a way to overwrite the class loader. This may be used to change the way how the PresenterFactory is found by the ServiceLoader