### PR TITLE
fix: Add javafx-fxml dep with provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
     </developers>
     <dependencies>
         <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>


### PR DESCRIPTION
Locally `mvn install` fails because `javafx-fxml` is not present as a dependency.