### PR TITLE
feat: Add Automatic-Module-Name to the generated jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${artifactId}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.0.201403182114</version>


### PR DESCRIPTION
With this change, maven would not fail when building
applications with JPMS where the `module-info.java` file
is present.

Currently the error when trying to use JLink is:

```
Error: automatic module cannot be used with jlink: afterburner.fx from
~/.m2/repository/com/airhacks/afterburner.fx/1.7.0/afterburner.fx-1.7.0.jar
[ERROR] Command execution failed.
```