### PR TITLE
fix: injection context order

### DIFF
--- a/src/test/java/com/airhacks/afterburner/views/SingleInjectionPresenter.java
+++ b/src/test/java/com/airhacks/afterburner/views/SingleInjectionPresenter.java
@@ -1,0 +1,39 @@
+package com.airhacks.afterburner.views;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2021 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import javafx.fxml.FXML;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+public class SingleInjectionPresenter {
+
+    @Inject
+    NoDefaultConstructor obj;
+
+    public static class NoDefaultConstructor {
+        public NoDefaultConstructor(String arg) {
+        }
+    }
+
+}

--- a/src/test/java/com/airhacks/afterburner/views/SingleInjectionTest.java
+++ b/src/test/java/com/airhacks/afterburner/views/SingleInjectionTest.java
@@ -1,0 +1,46 @@
+package com.airhacks.afterburner.views;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2021 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.airhacks.afterburner.views.SingleInjectionPresenter.NoDefaultConstructor;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class SingleInjectionTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void missingObject() {
+        new SingleInjectionView().getPresenter();
+    }
+
+    @Test
+    public void injectedObject() {
+        NoDefaultConstructor obj = new NoDefaultConstructor("");
+        SingleInjectionPresenter presenter = (SingleInjectionPresenter)new SingleInjectionView(
+                key -> "obj".equals(key) ? obj : null)
+                .getPresenter();
+        assertThat(presenter.obj, is(obj));
+    }
+
+}

--- a/src/test/java/com/airhacks/afterburner/views/SingleInjectionView.java
+++ b/src/test/java/com/airhacks/afterburner/views/SingleInjectionView.java
@@ -1,0 +1,35 @@
+package com.airhacks.afterburner.views;
+
+/*
+ * #%L
+ * afterburner.fx
+ * %%
+ * Copyright (C) 2013 - 2021 Adam Bien
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import java.util.function.Function;
+
+public class SingleInjectionView extends FXMLView {
+
+    public SingleInjectionView() {
+    }
+
+    public SingleInjectionView(Function<String, Object> injectionContext) {
+        super(injectionContext);
+    }
+
+}

--- a/src/test/java/com/airhacks/afterburner/views/singleinjection.fxml
+++ b/src/test/java/com/airhacks/afterburner/views/singleinjection.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane id="AnchorPane" prefHeight="400.0" prefWidth="600.0" styleClass="mainFxmlClass" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8" fx:controller="com.airhacks.afterburner.views.SingleInjectionPresenter">
+    <children><Pane prefHeight="200.0" prefWidth="200.0" />
+    </children></AnchorPane>


### PR DESCRIPTION
I keep running into issues with injecting context objects that do not have a default constructor. I unfortunately realized too late that there are already multiple issues and PRs open for this (#80, #85), but maybe the test helps with the review. I set it up as a minimal change set for cherry picking w/ no changes to the public API.

Afterburner works well with [JitPack](https://jitpack.io/), so for now I'm using the following temporary fix:

```xml
<repositories>
    <repository>
        <id>jitpack.io</id>
        <url>https://jitpack.io</url>
    </repository>
</repositories>
```

```xml
<dependency> <!-- com.airhacks:afterburner.fx:1.7.0 w/ injection context fix (PR #90) -->
    <groupId>com.github.ennerf</groupId>
    <artifactId>afterburner.fx</artifactId>
    <version>1.7.0-pr90</version>
</dependency>
```